### PR TITLE
Update cards for Feature Packs section & small server update

### DIFF
--- a/backend/routes/players/top-players.js
+++ b/backend/routes/players/top-players.js
@@ -47,7 +47,7 @@ router.get('/', async (req, res) => {
       avatar: player.avatar,
       name: player.name,
       score: player.pp,
-      change: weeklyChange(player.histories),
+      change: player.rank - player.lastWeekRank,
     }
   })
 

--- a/src/app.scss
+++ b/src/app.scss
@@ -69,8 +69,7 @@ h1 {
 }
 
 h2 {
-  font-size: 2.5rem;
-  line-height: 46px;
+  font-size: 1.5rem;
 }
 
 pre {
@@ -95,5 +94,9 @@ button:focus:not(:focus-visible) {
 @media (min-width: 720px) {
   h1 {
     font-size: 2.4rem;
+  }
+  h2 {
+    font-size: 2.5rem;
+    line-height: 46px;
   }
 }

--- a/src/lib/Cards.svelte
+++ b/src/lib/Cards.svelte
@@ -1,21 +1,21 @@
 <script lang="ts">
   import type { CardData } from '../types'
-  type ValidGridWidths = `${'3' | '4'}`
+  type ValidNumColumns = `${'3' | '4'}`
 
-  export let gridWidth: ValidGridWidths = '4'
+  export let maxColumns: ValidNumColumns = '4'
   export let cards: CardData[]
-  export let maxAmount: number | undefined = undefined // max amount of cards to show
+  export let maxCards: number | undefined = undefined // max amount of cards to show
   export let aspectRatio: number = 1
 
   const cardsToShow =
-    maxAmount !== undefined && maxAmount >= 0 ? cards.slice(0, Math.round(maxAmount)) : cards
-  const gridWidthClass = `gw-${gridWidth}`
+    maxCards !== undefined && maxCards >= 0 ? cards.slice(0, Math.round(maxCards)) : cards
+  const maxColsClass = `max-cols-${maxColumns}`
 </script>
 
-<div class="cards {gridWidthClass}" style="--aspect-ratio:{aspectRatio}">
+<div class="cards {maxColsClass}" style="--aspect-ratio:{aspectRatio}">
   {#each cardsToShow as card}
     <a class="card" href={`/posts/${card.slug}`} style={`background-image: url(${card.image})`}>
-      <div class="title {gridWidthClass}">
+      <div class="title {maxColsClass}">
         {card.title ?? ''}
       </div>
     </a>
@@ -52,7 +52,7 @@
       z-index: 1;
     }
 
-    &.gw-3 {
+    &.max-cols-3 {
       @media (min-width: 420px) {
         .title {
           @include little-title;
@@ -70,7 +70,7 @@
       }
     }
 
-    &.gw-4 {
+    &.max-cols-4 {
       @media (min-width: 420px) {
         grid-template-columns: repeat(2, 1fr);
         .title {

--- a/src/lib/Cards.svelte
+++ b/src/lib/Cards.svelte
@@ -46,6 +46,7 @@
 
     .title {
       @include big-title;
+      font-family: $font-poppins;
       margin-top: auto;
       color: white;
       font-weight: bold;

--- a/src/lib/Cards.svelte
+++ b/src/lib/Cards.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
-  export let cards
+  import type { CardData } from '../types'
+  type ValidGridWidths = `${'3' | '4'}`
+
+  export let gridWidth: ValidGridWidths = '4'
+  export let cards: CardData[]
+  export let maxAmount: number | undefined = undefined // max amount of cards to show
+  export let aspectRatio: number = 1
+
+  const cardsToShow =
+    maxAmount !== undefined && maxAmount >= 0 ? cards.slice(0, Math.round(maxAmount)) : cards
+  const gridWidthClass = `gw-${gridWidth}`
 </script>
 
-<div class="cards">
-  {#each cards as card}
+<div class="cards {gridWidthClass}" style="--aspect-ratio:{aspectRatio}">
+  {#each cardsToShow as card}
     <a class="card" href={`/posts/${card.slug}`} style={`background-image: url(${card.image})`}>
-      <div class="title">
+      <div class="title {gridWidthClass}">
         {card.title ?? ''}
       </div>
     </a>
@@ -14,55 +24,101 @@
 
 <style lang="scss">
   @import 'src/scss/variables';
+  $card-border-radius: 10px;
+
+  @mixin big-title {
+    padding: 1.25rem;
+    font-size: 2rem;
+    line-height: 2.375rem;
+  }
+
+  @mixin little-title {
+    padding: 0.75rem;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
 
   .cards {
     display: grid;
     grid-template-columns: repeat(1, 1fr);
     width: 100%;
-    gap: 12px;
-  }
+    gap: 0.75rem;
 
-  @media (min-width: 420px) {
-    .cards {
-      grid-template-columns: repeat(2, 1fr);
+    .title {
+      @include big-title;
+      margin-top: auto;
+      color: white;
+      font-weight: bold;
+      z-index: 1;
     }
-  }
 
-  @media (min-width: 840px) {
-    .cards {
-      grid-template-columns: repeat(4, 1fr);
+    &.gw-3 {
+      @media (min-width: 420px) {
+        .title {
+          @include little-title;
+        }
+      }
+
+      @media (min-width: 560px) {
+        grid-template-columns: repeat(3, 1fr);
+      }
+
+      @media (min-width: 840px) {
+        .title {
+          @include big-title;
+        }
+      }
+    }
+
+    &.gw-4 {
+      @media (min-width: 420px) {
+        grid-template-columns: repeat(2, 1fr);
+        .title {
+          @include little-title;
+        }
+      }
+
+      @media (min-width: 640px) {
+        .title {
+          @include big-title;
+        }
+      }
+
+      @media (min-width: 840px) {
+        grid-template-columns: repeat(4, 1fr);
+        .title {
+          @include little-title;
+        }
+      }
+
+      @media (min-width: 1100px) {
+        .title {
+          @include big-title;
+        }
+      }
     }
   }
 
   .card {
     position: relative;
     display: flex;
-    aspect-ratio: 1;
-    border-radius: $rounding;
+    border-radius: $card-border-radius;
     background-size: 100%;
     background-position: center;
     transition: 0.5s;
-  }
+    aspect-ratio: var(--aspect-ratio);
 
-  .card:hover {
-    background-size: 110%;
-  }
+    &:hover {
+      background-size: 110%;
+    }
 
-  .card::after {
-    content: '';
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    border-radius: $rounding;
-    background: transparent linear-gradient(180deg, #45408800 50%, #000000 100%) 0 0 no-repeat
-      padding-box;
-  }
-
-  .title {
-    margin-top: auto;
-    padding: 12px;
-    color: white;
-    font-size: 24px;
-    z-index: 1;
+    &:after {
+      content: '';
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      border-radius: $card-border-radius;
+      background: linear-gradient(180deg, rgba(69, 64, 136, 0) 0%, #000000 100%);
+    }
   }
 </style>

--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -10,19 +10,23 @@
 </script>
 
 <div class="container">
-  {#if icon}
-    <div class="icon">
-      <!-- TODO: Check for better way to style this -->
-      <Fa style="height:100%;width:100%;" class="fa" fw {icon} />
+  <div class="heading-container">
+    {#if icon}
+      <div class="icon">
+        <!-- TODO: Check for better way to style this -->
+        <Fa style="height:100%;width:100%;" class="fa" fw {icon} />
+      </div>
+    {/if}
+    <h2>{text}</h2>
+    <div class="accent-line-container">
+      <div class="line" />
     </div>
-  {/if}
-  <h2>{text}</h2>
-  <div class="accent-line-container">
-    <div class="line" />
   </div>
-  {#if linkText}
-    <IconLink {linkUrl} {linkText} />
-  {/if}
+  <div class="link-container">
+    {#if linkText}
+      <IconLink {linkUrl} {linkText} />
+    {/if}
+  </div>
 </div>
 
 <style lang="scss">
@@ -30,32 +34,60 @@
 
   .container {
     display: flex;
-    align-items: center;
+    padding: 0.5rem 0;
+    width: 100%;
     padding: 1rem 0;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    @media (min-width: 720px) {
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+
+  .heading-container {
+    display: flex;
+    align-items: center;
     width: 100%;
   }
 
-  .icon {
-    height: 2.5rem;
-    width: 2.5rem;
-    margin-right: 20px;
+  .link-container {
+    padding: 0;
+    margin: 0;
+    white-space: nowrap;
   }
+
+  .icon {
+    height: 1.5rem;
+    width: 1.5rem;
+    margin-right: 10px;
+
+    @media (min-width: 720px) {
+      height: 2.5rem;
+      width: 2.5rem;
+      margin-right: 20px;
+    }
+  }
+
   h2 {
     display: block;
   }
 
   .accent-line-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 0 20px;
-    height: 100%;
-    flex-grow: 1;
+    @media (min-width: 420px) {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 0 20px;
+      height: 100%;
+      flex-grow: 1;
 
-    .line {
-      height: 5px;
-      width: 100%;
-      background: linear-gradient(90deg, #999999 0%, rgba(153, 153, 153, 0) 100%);
+      .line {
+        height: 5px;
+        width: 100%;
+        background: linear-gradient(90deg, #999999 0%, rgba(153, 153, 153, 0) 100%);
+      }
     }
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,7 +32,7 @@
   <hr />
 
   <Header text="Latest News" icon={faNewspaper} />
-  <Cards {cards} gridWidth="3" maxAmount={maxNewsCards} aspectRatio={21 / 16} />
+  <Cards {cards} maxColumns="3" maxCards={maxNewsCards} aspectRatio={21 / 16} />
   <!-- ^^ replace cards with news data in future -->
 
   <Header
@@ -41,7 +41,7 @@
     linkUrl="/posts"
     linkText="See all curated packs"
   />
-  <Cards {cards} gridWidth="4" maxAmount={maxFeaturedPackCards} />
+  <Cards {cards} maxColumns="4" maxCards={maxFeaturedPackCards} />
 
   <Header text="Community Events" icon={faCalendarDay} />
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { CardData } from '../types'
+
   import QuickFilters from '$lib/QuickFilters.svelte'
   import Search from '$lib/Search.svelte'
   import Cards from '$lib/Cards.svelte'
@@ -6,13 +8,16 @@
   import Leaderboards from '$lib/Leaderboards.svelte'
 
   import { faNewspaper } from '@fortawesome/free-solid-svg-icons/faNewspaper'
-  import { faList } from '@fortawesome/free-solid-svg-icons/faList'
+  import { faRectangleList } from '@fortawesome/free-solid-svg-icons/faRectangleList'
   import { faAward } from '@fortawesome/free-solid-svg-icons/faAward'
   import { faCalendarDay } from '@fortawesome/free-solid-svg-icons/faCalendarDay'
   import { faChartLine } from '@fortawesome/free-solid-svg-icons/faChartLine'
 
   export let data
-  let cards = data.cards
+  let cards = data.cards as CardData[]
+
+  const maxNewsCards = 3
+  const maxFeaturedPackCards = 4
 </script>
 
 <svelte:head>
@@ -24,12 +29,19 @@
     <QuickFilters />
     <Search />
   </div>
-  <Cards {cards} />
   <hr />
 
   <Header text="Latest News" icon={faNewspaper} />
+  <Cards {cards} gridWidth="3" maxAmount={maxNewsCards} aspectRatio={21 / 16} />
+  <!-- ^^ replace cards with news data in future -->
 
-  <Header text="Featured Packs" icon={faList} />
+  <Header
+    text="Featured Packs"
+    icon={faRectangleList}
+    linkUrl="/posts"
+    linkText="See all curated packs"
+  />
+  <Cards {cards} gridWidth="4" maxAmount={maxFeaturedPackCards} />
 
   <Header text="Community Events" icon={faCalendarDay} />
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,7 @@
+export type CardData = {
+  slug: string
+  image: string
+  publish: string
+  title?: string
+  category?: string
+}


### PR DESCRIPTION
- Updated beat leader api to for new format of retrieved JSON related to ranks / last week's ranks
- Restyled cards for the Feature Packs section per the figma mockup (title text size, padding, 
- Cards can support 3 or 4 columns wide grid, and max amount of cards to show (3 is for news which is coming later)

