### PR TITLE
Better support for long post titles

### DIFF
--- a/src/scss/post-cards.scss
+++ b/src/scss/post-cards.scss
@@ -4,13 +4,13 @@ $card-border-radius: 10px;
 
 @mixin big-title {
   padding: 1.25rem;
-  font-size: 2rem;
+  font-size: 1.5rem;
   line-height: 2.375rem;
 }
 
 @mixin little-title {
   padding: 0.75rem;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   line-height: 1.75rem;
 }
 
@@ -26,6 +26,8 @@ $card-border-radius: 10px;
     margin-top: auto;
     color: white;
     font-weight: bold;
+    word-wrap: anywhere;
+    hyphens: auto; // For some reason this gets ignored on words with any capital letters
     z-index: 1;
   }
 


### PR DESCRIPTION
About line 30: This appears to be the intended behaviour, for whatever reason. 
As far as I can tell, there's no good way to solve it, but we might as well keep it for non-capitalized words.