### PR TITLE
Fix pagination issue in a hacky way

### DIFF
--- a/src/lib/PaginationBar.svelte
+++ b/src/lib/PaginationBar.svelte
@@ -29,6 +29,16 @@
     >
       {singlePageNumber}
     </a>
+    {#if forceExternal}
+      <!-- 
+        Solves issue #133.
+        Adding an invisible link to ensure the pages are all crawled - anchors with rel="external" are not crawled 
+        Ideally you'd want to try to avoid using force external, but in case of community events no other working solution was found
+      -->
+      <a style="display: none" href={getPageLink(singlePageNumber)}>
+        {singlePageNumber}
+      </a>
+    {/if}
   {/each}
   <a
     class="page-button"


### PR DESCRIPTION
Solves #133.
I personally don't like the solution, but for some reason not using external  - and thus forcing svelte to completely load the website instead of SPA navigating - just didn't yield results. There is very likely a better way to solve this, but I didn't find it and I expect it to be quite the time sink. I've sunk a bit of time into debugging this without finding a better solution.

The event card's each-iteration are keyed and the card div event receives an id. But that oddly doesn't seem to do the trick.

I think from the user perspective this hack works well enough. The difference between a complete refresh and SPA navigation is probably only noticable with slow Internet.

We could make a ticket for looking into and improving this.