### PR TITLE
Minor modification to PostPage.svelte

### DIFF
--- a/src/lib/PostPage.svelte
+++ b/src/lib/PostPage.svelte
@@ -148,9 +148,7 @@
       {#if lastUpdated}
         <span class="last-updated-time">Last updated on {formatDate(lastUpdated)}</span>
       {:else}
-        <span class="publication-time"
-          ><span class="hide-on-small">Published on </span>{formatDate(publish)}</span
-        >
+        <span class="hide-on-small">Published on </span>{formatDate(publish)}
       {/if}
     </div>
     <!-- ToDo: Put Post Category Tags here - might make a good component as they are used in three locations including this one -->
@@ -242,35 +240,27 @@
       justify-content: center;
       gap: 0.5rem;
     }
-    .author {
-      margin-bottom: 0.3rem;
-    }
   }
   @media (min-width: 553px) {
     .spacer {
       display: none;
     }
   }
-  .spacer {
-    text-align: center;
-  }
-  // Needs to be global so because it's rendered in with @html
-  :global(a.post-person-link) {
-    color: $color-danger-red;
-  }
   .author-information {
     margin-left: 0.5rem;
   }
-  .publication-time {
-    margin-right: 0.5rem;
-    color: $color-muted-text;
-  }
-  .last-updated-time {
-    margin-right: 0.5rem;
-    color: $color-muted-text;
+  .spacer {
+    text-align: center;
   }
   .publish-update {
     text-align: right;
+    color: $color-muted-text;
+    margin-right: 0.5rem;
+  }
+
+  // Needs to be global so because it's rendered in with @html
+  :global(a.post-person-link) {
+    color: $color-danger-red;
   }
 
   $pfp-diameter: 128px;
@@ -337,9 +327,6 @@
         margin: 0;
         border-radius: 0 0 $rounding-large - 2px $rounding-large - 2px; // Ensures the backdrop filter covers the entire image
       }
-    }
-    .last-updated-time {
-      float: right;
     }
 
     .hide-on-small {

--- a/src/lib/PostPage.svelte
+++ b/src/lib/PostPage.svelte
@@ -132,19 +132,28 @@
     </h1>
   {/if}
   <div class="meta-data-line">
-    <span>
-      {#if authors.length > 0}
-        <span class="author-information"
-          >Written by {@html prettyNameConcatenation(authors, scrollifyPerson)}</span
+    <div class="author">
+      <span>
+        {#if authors.length > 0}
+          <span class="author-information"
+            >Written by {@html prettyNameConcatenation(authors, scrollifyPerson)}<span
+              class="spacer"
+            >
+              |</span
+            ></span
+          >
+        {/if}
+      </span>
+    </div>
+    <div class="publish-update">
+      {#if lastUpdated}
+        <span class="last-updated-time">Last updated on {formatDate(lastUpdated)}</span>
+      {:else}
+        <span class="publication-time"
+          ><span class="hide-on-small">Published on </span>{formatDate(publish)}</span
         >
-        |{/if}
-      <span class="publication-time"
-        ><span class="hide-on-small">Published on </span>{formatDate(publish)}</span
-      >
-    </span>
-    {#if lastUpdated}
-      <span class="last-updated-time">Last updated on {formatDate(lastUpdated)}</span>
-    {/if}
+      {/if}
+    </div>
     <!-- ToDo: Put Post Category Tags here - might make a good component as they are used in three locations including this one -->
     <!-- <span class="category-labels"></span> -->
   </div>
@@ -224,6 +233,27 @@
     padding-bottom: 1rem;
     border-bottom: solid 3px $color-background-tertiary;
     width: 100%;
+    display: flex;
+    justify-content: space-between;
+  }
+  @media (max-width: 552px) {
+    .meta-data-line {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 0.5rem;
+    }
+    .author {
+      margin-bottom: 0.3rem;
+    }
+  }
+  @media (min-width: 553px) {
+    .spacer {
+      display: none;
+    }
+  }
+  .spacer {
+    padding-left: 1.5rem;
   }
   // Needs to be global so because it's rendered in with @html
   :global(a.post-person-link) {
@@ -231,21 +261,15 @@
   }
   .author-information {
     margin-right: 0.5rem;
+    padding-left: 0.5rem;
   }
   .publication-time {
     margin-left: 0.5rem;
+    padding-right: 0.5rem;
     color: $color-muted-text;
   }
   .last-updated-time {
     color: $color-muted-text;
-  }
-
-  .meta-data-line {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 1rem;
   }
 
   $pfp-diameter: 128px;
@@ -291,10 +315,6 @@
     cursor: pointer;
   }
 
-  .credit-line {
-    margin-top: 1rem;
-  }
-
   .hide-on-small {
     display: none;
   }
@@ -323,10 +343,6 @@
 
     .hide-on-small {
       display: inline;
-    }
-
-    .meta-data-line {
-      display: block;
     }
   }
 

--- a/src/lib/PostPage.svelte
+++ b/src/lib/PostPage.svelte
@@ -136,15 +136,14 @@
       <span>
         {#if authors.length > 0}
           <span class="author-information"
-            >Written by {@html prettyNameConcatenation(authors, scrollifyPerson)}<span
-              class="spacer"
-            >
-              |</span
-            ></span
-          >
+            >Written by {@html prettyNameConcatenation(authors, scrollifyPerson)}
+          </span>
         {/if}
       </span>
     </div>
+    {#if authors.length > 0}
+      <div class="spacer">|</div>
+    {/if}
     <div class="publish-update">
       {#if lastUpdated}
         <span class="last-updated-time">Last updated on {formatDate(lastUpdated)}</span>
@@ -233,8 +232,8 @@
     padding-bottom: 1rem;
     border-bottom: solid 3px $color-background-tertiary;
     width: 100%;
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
   }
   @media (max-width: 552px) {
     .meta-data-line {
@@ -253,24 +252,25 @@
     }
   }
   .spacer {
-    padding-left: 1.5rem;
+    text-align: center;
   }
   // Needs to be global so because it's rendered in with @html
   :global(a.post-person-link) {
     color: $color-danger-red;
   }
   .author-information {
-    margin-right: 0.5rem;
-    padding-left: 0.5rem;
+    margin-left: 0.5rem;
   }
   .publication-time {
-    margin-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-right: 0.5rem;
     color: $color-muted-text;
   }
   .last-updated-time {
+    margin-right: 0.5rem;
     color: $color-muted-text;
-    padding-right: 0.5rem;
+  }
+  .publish-update {
+    text-align: right;
   }
 
   $pfp-diameter: 128px;

--- a/src/lib/PostPage.svelte
+++ b/src/lib/PostPage.svelte
@@ -270,6 +270,7 @@
   }
   .last-updated-time {
     color: $color-muted-text;
+    padding-right: 0.5rem;
   }
 
   $pfp-diameter: 128px;


### PR DESCRIPTION
CSS might be over-engineered (my specialty...), but this would remove the Published date on post pages if the page has been updated and would then only display the "Updated on" date. It also justifies the content to space between; or centered on smaller screens; or a right aligned date only when there is no author listed.

Also removed lines 243-250 since I couldn't figure out what that was doing there considering that element was first introduced on line 222 (now 231) and the unused `.credit-line` element.

Lines 264, 268, & 273 aren't necessary, but I thought it looked better 🤷‍♂️