### PR TITLE
Add ability to expand MapCards

### DIFF
--- a/src/lib/MapCards.svelte
+++ b/src/lib/MapCards.svelte
@@ -143,7 +143,7 @@
 <!-- Conditionally show "Load More" button if loadMoreEnabled is true -->
 {#if loadMoreEnabled && visibleCount < maps.length}
   <div class="load-more-container">
-    <a href="#" on:click|preventDefault={loadMore} class="load-more">Show More</a>
+    <button on:click|preventDefault={loadMore} class="load-more">Show More</button>
   </div>
 {/if}
 
@@ -157,7 +157,6 @@
     grid-template-columns: repeat(1, 1fr);
     gap: 1.25rem;
     width: 100%;
-    transition: all 0.5s ease;
 
     @media (min-width: 992px) {
       grid-template-columns: repeat(2, 1fr);
@@ -176,14 +175,16 @@
   }
 
   .load-more {
+    background-color: $color-background-secondary;
+    border: none;
     color: $color-danger-red;
-    padding: 10px 95px;
+    padding: 10px 40px;
     border-radius: $rounding-large;
     transition: background-color $transition-long;
+    cursor: pointer;
 
     &:hover {
-      background-color: $color-background-secondary;
-      border-radius: $rounding-large;
+      text-decoration: underline;
     }
   }
 

--- a/src/lib/MapCards.svelte
+++ b/src/lib/MapCards.svelte
@@ -13,7 +13,7 @@
   import { audioPlayer } from '$lib/audio-player'
   import { beatSaverClientFactory } from './beatsaver-client'
   import CopyBsr from './CopyBSR.svelte'
-  import { slide } from 'svelte/transition' // Import the slide transition
+  import { slide } from 'svelte/transition'
 
   export let sortOrder: 'FIRST_PUBLISHED' | 'UPDATED' | 'LAST_PUBLISHED' | 'CREATED' | 'CURATED' =
     'FIRST_PUBLISHED'
@@ -82,7 +82,6 @@
   {#if maps.length !== 0}
     {#each maps.slice(0, visibleCount) as map (map.id)}
       <div class="card-wrapper" transition:slide={{ duration: 300 }}>
-        <!-- Apply slide transition here -->
         <div class="card">
           <div class="image-container">
             <img

--- a/src/lib/MapCards.svelte
+++ b/src/lib/MapCards.svelte
@@ -176,8 +176,15 @@
   }
 
   .load-more {
-    color: #e95d4e;
-    cursor: pointer;
+    color: $color-danger-red;
+    padding: 10px 95px;
+    border-radius: $rounding-large;
+    transition: background-color $transition-long;
+
+    &:hover {
+      background-color: $color-background-secondary;
+      border-radius: $rounding-large;
+    }
   }
 
   .card-wrapper {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -99,7 +99,7 @@
     }/?order=Curated&curated=true`}
     linkText="See all curated maps"
   />
-  <MapCards sortOrder="CURATED" />
+  <MapCards sortOrder="CURATED" loadMoreEnabled={true} />
 
   <Header
     text="Recent Maps by Verified Mappers"
@@ -107,7 +107,7 @@
     linkUrl={`${import.meta.env.VITE_BEATSAVER_BASE || 'https://beatsaver.com'}/?verified=true`}
     linkText="See all maps by verified mappers"
   />
-  <MapCards verified={true} />
+  <MapCards verified={true} loadMoreEnabled={true} />
 
   <Header
     text="Community Events"


### PR DESCRIPTION
This adds the ability to click a "Show More" button below the Curated and Verified Mappers feeds which expands the number of maps displayed by intervals of 8, and maxing out at 100.
Would it be a good idea to add a "Reset" button next to the "Show More" button to return to the original 8 displayed without having to refresh the page?