### PR TITLE
Implement motw skip logic

### DIFF
--- a/src/collections/map-of-the-week/2022-05-16T00_00_00.000Z.md
+++ b/src/collections/map-of-the-week/2022-05-16T00_00_00.000Z.md
@@ -2,5 +2,6 @@
 mapId: "2596b"
 review: "This map stands out for its super fun patterns and emphasis that represent the music perfectly, great chroma  light show that fits the song equally beautifully and accessible full spread that maintains the energy on all the diffs!"
 startDate: "2022-05-16T00:00:00.000Z"
+hide: true
 coverUrlOverwrite: https://cdn.assets.beatleader.xyz/songcover-2596b-cover.jpg
 ---

--- a/src/lib/getMapsOfTheWeekNetlifyData.ts
+++ b/src/lib/getMapsOfTheWeekNetlifyData.ts
@@ -13,8 +13,11 @@ export const getSortedMapsOfTheWeekNetlifyData = async () => {
     }),
   )
 
-  const mapsOfTheWeeksToShow = unsortedMapsOfTheWeeks.filter(
-    (motw) => motw.startDate.getTime() <= new Date().getTime(),
+
+  const mapsOfTheWeeksToShow = unsortedMapsOfTheWeeks
+  .filter((motw) => motw.hide !== true)
+  .filter(
+    (motw) => motw.startDate.getTime() <= new Date().getTime() ,
   )
 
   return mapsOfTheWeeksToShow

--- a/src/routes/maps-of-the-week/[page]/+page.server.ts
+++ b/src/routes/maps-of-the-week/[page]/+page.server.ts
@@ -57,6 +57,10 @@ export async function load({
         `https://cdn.assets.beatleader.xyz/songcover-${singleMapOfTheWeek.mapId}-full.webp`
 
       const beatSaverMapData = allBeatSaverMapData[singleMapOfTheWeek.mapId]
+      if(beatSaverMapData == null) {
+        console.warn(`Map of the Week with the id ${singleMapOfTheWeek.mapId} does not seem to exist - skipping.`);
+        continue;
+      }
 
       paginatedFullMapsOfTheWeek.push({
         map: beatSaverMapData,

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,8 @@ export type MapOfTheWeekCollectionData = {
   showcase?: {
     id?: string
     type?: 'youtube-short' | 'youtube-video'
-  }
+  },
+  hide?: boolean;
   coverUrlOverwrite?: string
 }
 


### PR DESCRIPTION
This PR will introduce a hide variable (which is not part of the CMS though) to manually skip the MotW that causes issues while keeping pagination intact.

It introduces a second mechanism in which it does not display the map if it wasn't found on BeatSaver, but ruins the pagination (the page will just be reduced by the entry, so instead of 10 it may be 9).