### PR TITLE
Add NSFW toggle to Footer

### DIFF
--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -6,6 +6,7 @@
   import { faXTwitter } from '@fortawesome/free-brands-svg-icons'
 
   import { showNSFW } from './storeNsfwPreference'
+  import { toggleVisibility } from './storeNsfwPreference'
 
   function toggleNSFW() {
     showNSFW.update((value) => !value)
@@ -13,16 +14,18 @@
 </script>
 
 <footer>
-  <div class="nsfw-toggle-container">
-    <span class="toggle-title">NSFW Filter:</span>
-    <div class="toggle-wrapper" on:click={toggleNSFW}>
-      <div class="toggle-pill" class:active={$showNSFW}>
-        <span class="toggle-status">
-          {#if $showNSFW}ON{:else}OFF{/if}
-        </span>
+  {#if $toggleVisibility}
+    <div class="nsfw-toggle-container">
+      <span class="toggle-title">NSFW Filter</span>
+      <div class="toggle-wrapper" on:click={toggleNSFW}>
+        <div class="toggle-pill" class:active={$showNSFW}>
+          <span class="toggle-status"
+            >{#if $showNSFW}ON{:else}OFF{/if}</span
+          >
+        </div>
       </div>
     </div>
-  </div>
+  {/if}
   <hr />
   <div class="footer-content">
     <div>

--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -5,24 +5,22 @@
   import { faYoutube } from '@fortawesome/free-brands-svg-icons'
   import { faXTwitter } from '@fortawesome/free-brands-svg-icons'
 
-  import { showNSFW } from './storeNsfwPreference'
-  import { toggleVisibility } from './storeNsfwPreference'
+  import { filterNsfw } from './storeNsfwPreference'
+  import { nsfwToggleVisibility } from './storeNsfwPreference'
 
   function toggleNSFW() {
-    showNSFW.update((value) => !value)
+    filterNsfw.update((value) => !value)
   }
 </script>
 
 <footer>
-  {#if $toggleVisibility}
+  {#if $nsfwToggleVisibility}
     <div class="nsfw-toggle-container">
       <div class="nsfw-component" title="Toggle blur for NSFW covers if present">
         <span class="toggle-title">NSFW Filter:</span>
         <div class="toggle-wrapper" on:click={toggleNSFW}>
-          <div class="toggle-pill" class:active={$showNSFW}>
-            <span class="toggle-status"
-              >{#if $showNSFW}ON{:else}OFF{/if}</span
-            >
+          <div class="toggle-pill" class:active={$filterNsfw}>
+            <span class="toggle-status">{$filterNsfw ? 'ON' : 'OFF'}</span>
           </div>
         </div>
       </div>

--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -16,12 +16,14 @@
 <footer>
   {#if $toggleVisibility}
     <div class="nsfw-toggle-container">
-      <span class="toggle-title">NSFW Filter</span>
-      <div class="toggle-wrapper" on:click={toggleNSFW}>
-        <div class="toggle-pill" class:active={$showNSFW}>
-          <span class="toggle-status"
-            >{#if $showNSFW}ON{:else}OFF{/if}</span
-          >
+      <div class="nsfw-component" title="Toggle blur for NSFW covers if present">
+        <span class="toggle-title">NSFW Filter:</span>
+        <div class="toggle-wrapper" on:click={toggleNSFW}>
+          <div class="toggle-pill" class:active={$showNSFW}>
+            <span class="toggle-status"
+              >{#if $showNSFW}ON{:else}OFF{/if}</span
+            >
+          </div>
         </div>
       </div>
     </div>
@@ -65,6 +67,7 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
+    margin-bottom: 1rem;
   }
   .footer-content {
     position: relative;
@@ -100,12 +103,20 @@
   }
 
   .nsfw-toggle-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .nsfw-component {
     text-align: center;
-    margin: 1.5rem;
+    margin: 0 1.5rem 1.5rem 1.5rem;
+    width: max-content;
   }
 
   .toggle-title {
     color: white;
+    font-weight: bold;
   }
 
   .toggle-wrapper {

--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -13,6 +13,16 @@
 </script>
 
 <footer>
+  <div class="nsfw-toggle-container">
+    <span class="toggle-title">NSFW Filter:</span>
+    <div class="toggle-wrapper" on:click={toggleNSFW}>
+      <div class="toggle-pill" class:active={$showNSFW}>
+        <span class="toggle-status">
+          {#if $showNSFW}ON{:else}OFF{/if}
+        </span>
+      </div>
+    </div>
+  </div>
   <hr />
   <div class="footer-content">
     <div>
@@ -43,16 +53,6 @@
         </li>
       </ul>
     </div>
-    <div class="nsfw-toggle-container">
-      <span class="toggle-title">NSFW Filter:</span>
-      <div class="toggle-wrapper" on:click={toggleNSFW}>
-        <div class="toggle-pill" class:active={$showNSFW}>
-          <span class="toggle-status">
-            {#if $showNSFW}ON{:else}OFF{/if}
-          </span>
-        </div>
-      </div>
-    </div>
   </div>
 </footer>
 
@@ -76,7 +76,7 @@
   }
 
   .links-container {
-    margin-top: 0.5rem;
+    margin: 0.5rem;
   }
 
   .links {
@@ -98,6 +98,7 @@
 
   .nsfw-toggle-container {
     text-align: center;
+    margin: 1.5rem;
   }
 
   .toggle-title {

--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -4,6 +4,12 @@
   import { faPatreon } from '@fortawesome/free-brands-svg-icons'
   import { faYoutube } from '@fortawesome/free-brands-svg-icons'
   import { faXTwitter } from '@fortawesome/free-brands-svg-icons'
+
+  import { showNSFW } from './storeNsfwPreference'
+
+  function toggleNSFW() {
+    showNSFW.update((value) => !value)
+  }
 </script>
 
 <footer>
@@ -37,6 +43,16 @@
         </li>
       </ul>
     </div>
+    <div class="nsfw-toggle-container">
+      <span class="toggle-title">NSFW Filter:</span>
+      <div class="toggle-wrapper" on:click={toggleNSFW}>
+        <div class="toggle-pill" class:active={$showNSFW}>
+          <span class="toggle-status">
+            {#if $showNSFW}ON{:else}OFF{/if}
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
 </footer>
 
@@ -60,7 +76,7 @@
   }
 
   .links-container {
-    margin: 0.5rem;
+    margin-top: 0.5rem;
   }
 
   .links {
@@ -78,5 +94,43 @@
 
   .logo {
     height: 25px;
+  }
+
+  .nsfw-toggle-container {
+    text-align: center;
+  }
+
+  .toggle-title {
+    color: white;
+  }
+
+  .toggle-wrapper {
+    display: inline-block;
+    cursor: pointer;
+  }
+
+  .toggle-pill {
+    width: 60px;
+    height: 25px;
+    background-color: $color-danger-red;
+    border-radius: 15px;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    font-weight: bold;
+    color: white;
+    transition: background-color 0.3s;
+    margin-left: 5px;
+  }
+
+  .toggle-pill.active {
+    background-color: $color-success-green;
+  }
+
+  .toggle-status {
+    position: relative;
+    z-index: 1;
   }
 </style>

--- a/src/lib/MapCards.svelte
+++ b/src/lib/MapCards.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Beatmap } from '../types'
-  import { onMount } from 'svelte'
+  import { onMount, onDestroy } from 'svelte'
   import Uploader from '$lib/Uploader.svelte'
   import Tags from '$lib/Tags.svelte'
   import Difficulties from '$lib/Difficulties.svelte'
@@ -15,6 +15,7 @@
   import CopyBsr from './CopyBSR.svelte'
   import { slide } from 'svelte/transition'
   import { showNSFW } from './storeNsfwPreference'
+  import { toggleVisibility } from './storeNsfwPreference'
 
   export let sortOrder: 'Latest' | 'Relevance' | 'Rating' | 'Curated' | 'Random' = 'Latest'
   export let verified: boolean | undefined = undefined
@@ -30,7 +31,12 @@
   const setPreviewKey = (key: string | null) => (previewKey = key)
 
   onMount(async () => {
+    toggleVisibility.set(true)
     await getMaps()
+  })
+
+  onDestroy(() => {
+    toggleVisibility.set(false)
   })
 
   const beatSaverClient = beatSaverClientFactory.create()

--- a/src/lib/MapCards.svelte
+++ b/src/lib/MapCards.svelte
@@ -14,8 +14,8 @@
   import { beatSaverClientFactory } from './beatsaver-client'
   import CopyBsr from './CopyBSR.svelte'
   import { slide } from 'svelte/transition'
-  import { showNSFW } from './storeNsfwPreference'
-  import { toggleVisibility } from './storeNsfwPreference'
+  import { filterNsfw } from './storeNsfwPreference'
+  import { nsfwToggleVisibility } from './storeNsfwPreference'
 
   export let sortOrder: 'Latest' | 'Relevance' | 'Rating' | 'Curated' | 'Random' = 'Latest'
   export let verified: boolean | undefined = undefined
@@ -31,12 +31,12 @@
   const setPreviewKey = (key: string | null) => (previewKey = key)
 
   onMount(async () => {
-    toggleVisibility.set(true)
+    nsfwToggleVisibility.set(true)
     await getMaps()
   })
 
   onDestroy(() => {
-    toggleVisibility.set(false)
+    nsfwToggleVisibility.set(false)
   })
 
   const beatSaverClient = beatSaverClientFactory.create()
@@ -95,7 +95,7 @@
                 map.versions[0].hash
               }.jpg`}
               alt={map.name}
-              class:blur={$showNSFW && map.nsfw}
+              class:blur={$filterNsfw && map.nsfw}
             />
             <div
               class="button-overlay"

--- a/src/lib/MapCards.svelte
+++ b/src/lib/MapCards.svelte
@@ -14,6 +14,7 @@
   import { beatSaverClientFactory } from './beatsaver-client'
   import CopyBsr from './CopyBSR.svelte'
   import { slide } from 'svelte/transition'
+  import { showNSFW } from './storeNsfwPreference'
 
   export let sortOrder: 'Latest' | 'Relevance' | 'Rating' | 'Curated' | 'Random' = 'Latest'
   export let verified: boolean | undefined = undefined
@@ -88,7 +89,7 @@
                 map.versions[0].hash
               }.jpg`}
               alt={map.name}
-              class:blur={map.nsfw === true}
+              class:blur={$showNSFW && map.nsfw}
             />
             <div
               class="button-overlay"

--- a/src/lib/Search.svelte
+++ b/src/lib/Search.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { slide } from 'svelte/transition'
+  import { showNSFW } from './storeNsfwPreference'
 
   const dropdownItems: {
     name: string
@@ -178,7 +179,7 @@
       {#each previewResults as preview}
         <a class="dropdown-item" href={preview.url}>
           <div class="image-wrapper">
-            <img src={preview.image} class:blur={preview.nsfw === true} alt="Map Thumbnail" />
+            <img src={preview.image} class:blur={$showNSFW && preview.nsfw} alt="Map Thumbnail" />
           </div>
           <div class="dropdown-item-map-name">
             {preview.name}<br />

--- a/src/lib/Search.svelte
+++ b/src/lib/Search.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
   import { slide } from 'svelte/transition'
   import { showNSFW } from './storeNsfwPreference'
+  import { toggleVisibility } from './storeNsfwPreference'
+  import { onMount, onDestroy } from 'svelte'
+
+  onMount(() => {
+    toggleVisibility.set(true)
+  })
+
+  onDestroy(() => {
+    toggleVisibility.set(false)
+  })
 
   const dropdownItems: {
     name: string

--- a/src/lib/Search.svelte
+++ b/src/lib/Search.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import { slide } from 'svelte/transition'
-  import { showNSFW } from './storeNsfwPreference'
-  import { toggleVisibility } from './storeNsfwPreference'
+  import { filterNsfw } from './storeNsfwPreference'
+  import { nsfwToggleVisibility } from './storeNsfwPreference'
   import { onMount, onDestroy } from 'svelte'
 
   onMount(() => {
-    toggleVisibility.set(true)
+    nsfwToggleVisibility.set(true)
   })
 
   onDestroy(() => {
-    toggleVisibility.set(false)
+    nsfwToggleVisibility.set(false)
   })
 
   const dropdownItems: {
@@ -189,7 +189,7 @@
       {#each previewResults as preview}
         <a class="dropdown-item" href={preview.url}>
           <div class="image-wrapper">
-            <img src={preview.image} class:blur={$showNSFW && preview.nsfw} alt="Map Thumbnail" />
+            <img src={preview.image} class:blur={$filterNsfw && preview.nsfw} alt="Map Thumbnail" />
           </div>
           <div class="dropdown-item-map-name">
             {preview.name}<br />

--- a/src/lib/storeNsfwPreference.js
+++ b/src/lib/storeNsfwPreference.js
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store'
 
 export const showNSFW = writable(true) // Default setting to true
+export const toggleVisibility = writable(false)
 
 if (typeof window !== 'undefined') {
   const storedPreference = localStorage.getItem('showNSFW')

--- a/src/lib/storeNsfwPreference.js
+++ b/src/lib/storeNsfwPreference.js
@@ -1,15 +1,15 @@
 import { writable } from 'svelte/store'
 
-export const showNSFW = writable(true) // Default setting to true
-export const toggleVisibility = writable(false)
+export const filterNsfw = writable(true) // Default setting to true
+export const nsfwToggleVisibility = writable(false)
 
-if (typeof window !== 'undefined') {
-  const storedPreference = localStorage.getItem('showNSFW')
-  if (storedPreference !== null) {
-    showNSFW.set(JSON.parse(storedPreference))
+if (typeof window != 'undefined') {
+  const storedPreference = localStorage.getItem('filterNsfw')
+  if (storedPreference != null) {
+    filterNsfw.set(JSON.parse(storedPreference))
   }
 
-  showNSFW.subscribe((value) => {
-    localStorage.setItem('showNSFW', JSON.stringify(value))
+  filterNsfw.subscribe((value) => {
+    localStorage.setItem('filterNsfw', JSON.stringify(value))
   })
 }

--- a/src/lib/storeNsfwPreference.js
+++ b/src/lib/storeNsfwPreference.js
@@ -1,0 +1,14 @@
+import { writable } from 'svelte/store'
+
+export const showNSFW = writable(true) // Default setting to true
+
+if (typeof window !== 'undefined') {
+  const storedPreference = localStorage.getItem('showNSFW')
+  if (storedPreference !== null) {
+    showNSFW.set(JSON.parse(storedPreference))
+  }
+
+  showNSFW.subscribe((value) => {
+    localStorage.setItem('showNSFW', JSON.stringify(value))
+  })
+}


### PR DESCRIPTION
Similar to BeatSaver's new addition of an NSFW user toggle, this adds the ability to turn off the NSFW filtering in the MapCards and the Search by means of localstorage since we don't have accounts.

This was initially going to go in the MapCards element but on the homepage, it would've shown up twice since the MapCards is duplicated for Curated and Verified feeds. That also wouldn't solve the problem of the Search not being targeted or needing to be targeted separately. I am completely open to suggestions on placement of this or improvements.